### PR TITLE
Use latest firmware file when flashing instead of hard coding file names

### DIFF
--- a/STEP 5 - Flash Firmware Update/FlashUpdate.bat
+++ b/STEP 5 - Flash Firmware Update/FlashUpdate.bat
@@ -17,6 +17,7 @@ for /f "delims=" %%a in ('dir /b /a-d /o-d "%folder%\*.mcs" 2^>nul') do (
 )
 if not defined latestFile (
     echo No .mcs files found in the directory.
+	pause
     exit /b
 )
 

--- a/STEP 5 - Flash Firmware Update/FlashUpdate.bat
+++ b/STEP 5 - Flash Firmware Update/FlashUpdate.bat
@@ -1,5 +1,42 @@
 @echo off
+setlocal enabledelayedexpansion
 
+set folder=%~dp0
+set latestFile=
+set latestTimestamp=0
+set impactFile="%~dp0write_mcs.impact"
+
+for /f "delims=" %%a in ('dir /b /a-d /o-d "%folder%\*.mcs" 2^>nul') do (
+    set fileTimestamp=%%~ta
+    set fileTimestamp=!fileTimestamp:~0,14!!fileTimestamp:~17,2!
+    
+    if "!fileTimestamp!" gtr "!latestTimestamp!" (
+        set latestTimestamp=!fileTimestamp!
+        set latestFile=%%a
+    )
+)
+if not defined latestFile (
+    echo No .mcs files found in the directory.
+    exit /b
+)
+
+
+echo setMode -bs > %impactFile%
+echo setMode -bs >> %impactFile%
+echo setMode -bs >> %impactFile%
+echo setMode -bs >> %impactFile%
+echo setCable -port auto >> %impactFile%
+echo Identify -inferir >> %impactFile%
+echo identifyMPM >> %impactFile%
+echo attachflash -position 1 -spi "W25Q64BV" >> %impactFile%
+echo assignfiletoattachedflash -position 1 -file "./%latestFile%" >> %impactFile%
+echo Program -p 1 -dataWidth 1 -spionly -e -v -loadfpga >> %impactFile%
+echo exit >> %impactFile%
+
+
+
+
+@echo Flashing using %latestFile%
 @echo Firmware update about to begin
 @echo Leave device powered on and plugged in until process is complete!!!
 pause

--- a/STEP 5 - Flash Firmware Update/FlashUpdate.bat
+++ b/STEP 5 - Flash Firmware Update/FlashUpdate.bat
@@ -22,17 +22,17 @@ if not defined latestFile (
 )
 
 
-echo setMode -bs > %impactFile%
-echo setMode -bs >> %impactFile%
-echo setMode -bs >> %impactFile%
-echo setMode -bs >> %impactFile%
-echo setCable -port auto >> %impactFile%
-echo Identify -inferir >> %impactFile%
-echo identifyMPM >> %impactFile%
-echo attachflash -position 1 -spi "W25Q64BV" >> %impactFile%
-echo assignfiletoattachedflash -position 1 -file "./%latestFile%" >> %impactFile%
-echo Program -p 1 -dataWidth 1 -spionly -e -v -loadfpga >> %impactFile%
-echo exit >> %impactFile%
+echo setMode -bs> %impactFile%
+echo setMode -bs>> %impactFile%
+echo setMode -bs>> %impactFile%
+echo setMode -bs>> %impactFile%
+echo setCable -port auto>> %impactFile%
+echo Identify -inferir>> %impactFile%
+echo identifyMPM>> %impactFile%
+echo attachflash -position 1 -spi "W25Q64BV">> %impactFile%
+echo assignfiletoattachedflash -position 1 -file "./%latestFile%">> %impactFile%
+echo Program -p 1 -dataWidth 1 -spionly -e -v -loadfpga>> %impactFile%
+echo exit>> %impactFile%
 
 
 

--- a/STEP 5 - Flash Firmware Update/FlashUpdate.bat
+++ b/STEP 5 - Flash Firmware Update/FlashUpdate.bat
@@ -17,7 +17,7 @@ for /f "delims=" %%a in ('dir /b /a-d /o-d "%folder%\*.mcs" 2^>nul') do (
 )
 if not defined latestFile (
     echo No .mcs files found in the directory.
-	pause
+    pause
     exit /b
 )
 


### PR DESCRIPTION
The enhancement to the flash script should let users copy the firmware files directly from the repository without having to rename them (less questions and issues raised if updates fail).