### PR TITLE
Update the Xilinx LabTools download URL to resolve a 404 error

### DIFF
--- a/STEP 2 - Download and Install LabTools/Link-to-Labtools-Download.txt
+++ b/STEP 2 - Download and Install LabTools/Link-to-Labtools-Download.txt
@@ -1,1 +1,1 @@
-https://www.xilinx.com/member/forms/download/xef-ise.html?filename=Xilinx_LabTools_14.7_1015_1.tar
+https://account.amd.com/en/forms/downloads/xef.html?filename=Xilinx_LabTools_14.7_1015_1.tar


### PR DESCRIPTION
At present, the URL in `./STEP 2 - Download and Install LabTools/Link-to-Labtools-Download.txt` points to a stale URL. When navigating to this URL to download `Xilinx_LabTools_14.7_1015_1.tar`, an `HTTP 404 NOT FOUND` error is raised.

![image](https://github.com/GameboxSystems/Firmware-Update-Install-Scripts/assets/5852376/c1549bae-7a0d-4929-ba4e-b8aa53d50505)

After doing some research, it was discovered that the URL has been changed to [https://account.amd.com/en/forms/downloads/xef.html?filename=Xilinx_LabTools_14.7_1015_1.tar](https://account.amd.com/en/forms/downloads/xef.html?filename=Xilinx_LabTools_14.7_1015_1.tar). This update resolves the issue above.

This fixes issue #4.